### PR TITLE
feat: Add Laravel 13 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,37 @@
+name: Tests
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['8.2', '8.3', '8.4']
+        laravel: ['10.*', '11.*', '12.*', '13.*']
+
+    name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: dom, curl, libxml, mbstring, zip
+          coverage: none
+
+      - name: Install dependencies
+        run: |
+          composer require "illuminate/support:${{ matrix.laravel }}" --no-interaction --no-update
+          composer update --prefer-dist --no-interaction
+
+      - name: Run tests
+        run: vendor/bin/phpunit --no-coverage
+        if: hashFiles('phpunit.xml') != '' || hashFiles('phpunit.xml.dist') != ''

--- a/README.md
+++ b/README.md
@@ -2,12 +2,18 @@
 Drop-in Categories for your Laravel apps with a Nova admin dashboard.
 
 ## Requirements
-- PHP 7.3+
-- Laravel 7.x
-- Laravel Nova 3.x
-- TailwindCSS 1.6+
-- TailwindUI 0.4+
-- Tailwind Typography 0.2+
+- PHP 8.2+
+- Laravel 10.x, 11.x, 12.x, or 13.x
+- Laravel Nova 4.x or 5.x
+
+## Supported Versions
+
+| Laravel | PHP  | Status       |
+|---------|------|--------------|
+| 13.x    | 8.2+ | ✅ Supported |
+| 12.x    | 8.2+ | ✅ Supported |
+| 11.x    | 8.2+ | ✅ Supported |
+| 10.x    | 8.2+ | ✅ Supported |
 
 ## Installation
 ```sh

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "genealabs/laravel-overridable-model": "*",
-        "illuminate/support": "^10.0|^11.0|^12.0",
+        "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
         "laravel/nova": "^4.0|^5.0",
         "php": "^8.2",
         "symfony/thanks": "^1.2"


### PR DESCRIPTION
Fixes: #2

## Changes

- **composer.json**: Updated `illuminate/support` constraint from `^10.0|^11.0|^12.0` to `^10.0|^11.0|^12.0|^13.0`
- **CI**: Added GitHub Actions workflow (`.github/workflows/tests.yml`) with test matrix covering PHP 8.2–8.4 × Laravel 10–13
- **README**: Updated requirements section to reflect current PHP/Laravel/Nova versions and added version support table

## Notes

- Reviewed all source files (service providers, Nova resources, controllers, models) — all use standard Laravel APIs that remain fully compatible with Laravel 13
- No breaking changes identified that affect this package