### PR TITLE
feat: Add Laravel 13 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,9 @@
 Drop-in Categories for your Laravel apps with a Nova admin dashboard.
 
 ## Requirements
-- PHP 7.3+
-- Laravel 7.x
-- Laravel Nova 3.x
-- TailwindCSS 1.6+
-- TailwindUI 0.4+
-- Tailwind Typography 0.2+
+- PHP 8.2+
+- Laravel 10.x, 11.x, 12.x, or 13.x
+- Laravel Nova 4.x or 5.x
 
 ## Installation
 ```sh

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "genealabs/laravel-overridable-model": "*",
-        "illuminate/support": "^10.0|^11.0|^12.0",
+        "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
         "laravel/nova": "^4.0|^5.0",
         "php": "^8.2",
         "symfony/thanks": "^1.2"


### PR DESCRIPTION
Fixes: #2

## Changes
- Updated `illuminate/support` version constraint in `composer.json` to include `^13.0`
- Updated README requirements section to reflect currently supported versions (PHP 8.2+, Laravel 10-13, Nova 4-5)

## Notes
- Reviewed all source files for Laravel 13 breaking changes — none affect this package
- The package uses standard Eloquent models, service providers, and Nova resources that are fully compatible with Laravel 13
- No CI workflow exists in the repo to add a Laravel 13 matrix job to