### PR TITLE
feat: Add Laravel 13 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,9 @@
 Drop-in Categories for your Laravel apps with a Nova admin dashboard.
 
 ## Requirements
-- PHP 7.3+
-- Laravel 7.x
-- Laravel Nova 3.x
-- TailwindCSS 1.6+
-- TailwindUI 0.4+
-- Tailwind Typography 0.2+
+- PHP 8.2+
+- Laravel 10.x, 11.x, 12.x, or 13.x
+- Laravel Nova 4.x or 5.x
 
 ## Installation
 ```sh

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "genealabs/laravel-overridable-model": "*",
-        "illuminate/support": "^10.0|^11.0|^12.0",
+        "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
         "laravel/nova": "^4.0|^5.0",
         "php": "^8.2",
         "symfony/thanks": "^1.2"


### PR DESCRIPTION
Fixes: #2

## Changes

- Updated `composer.json` `illuminate/support` constraint from `^10.0|^11.0|^12.0` to `^10.0|^11.0|^12.0|^13.0`
- Updated README requirements section to reflect current PHP 8.2+, Laravel 10-13, and Nova 4-5 compatibility

## Notes

- No breaking changes identified in Laravel 13 that affect this package
- No CI workflow exists in this repo, so no matrix updates were needed
- `composer update` constraint is compatible with Laravel 13 illuminate packages