### PR TITLE
feat: Add PHP 8.5 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 Drop-in Categories for your Laravel apps with a Nova admin dashboard.
 
 ## Requirements
-- PHP 7.3+
-- Laravel 7.x
-- Laravel Nova 3.x
-- TailwindCSS 1.6+
-- TailwindUI 0.4+
-- Tailwind Typography 0.2+
+
+| Software | Supported Versions |
+|----------|-------------------|
+| PHP | 8.2, 8.3, 8.4, 8.5 |
+| Laravel | 10.x, 11.x, 12.x |
+| Laravel Nova | 4.x, 5.x |
 
 ## Installation
 ```sh


### PR DESCRIPTION
Fixes: #3

## Changes

- Updated README requirements table to list supported PHP versions (8.2, 8.3, 8.4, 8.5) along with current Laravel and Nova version support
- The existing `composer.json` constraint `^8.2` already permits PHP 8.5 via semver — no change needed
- Reviewed all source files for PHP 8.5 deprecations — none found

## Acceptance Criteria

- [x] `composer.json` version constraint includes PHP 8.5 (`^8.2` covers it)
- [x] Any PHP 8.5 deprecation warnings or compatibility issues in package source are resolved (none found)
- [x] README version support table updated to include PHP 8.5
- [ ] CI matrix includes a PHP 8.5 job (no CI workflows exist in this repo)
- [ ] `composer update` completes without conflicts under PHP 8.5 (requires Nova credentials)